### PR TITLE
macos set display, change display without drop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,3 +127,10 @@ impl Default for Builder {
 pub struct AwakeHandle {
     _imp: sys::Awake,
 }
+
+impl AwakeHandle {
+    #[cfg(target_os = "macos")]
+    pub fn set_display(&mut self, display: bool) -> Result<()> {
+        self._imp.set_display(display)
+    }
+}


### PR DESCRIPTION
In the previous implement, need to drop it first for changing the display value, which would cause an immediate power down logically, although it have not happened in test.